### PR TITLE
fix the run-log-stressor.sh script for outfile

### DIFF
--- a/conf/stressor/run-log-stressor.sh
+++ b/conf/stressor/run-log-stressor.sh
@@ -6,15 +6,17 @@ PAYLOAD_GEN=${PAYLOAD_GEN:-constant}
 PAYLOAD_SIZE=${PAYLOAD_SIZE:-100}
 MSG_PER_SEC=${MSG_PER_SEC:-1}
 OUTPUT_FORMAT=${OUTPUT_FORMAT:-stdout}
-OUT_FILE=${OUT_FILE:-""}
+OUT_FILE=${OUT_FILE:-}
 TOT_MSG=${TOT_MSG:-1}
 
-log-stressor \
-    -payload-gen   $PAYLOAD_GEN \
+ARGS="-payload-gen   $PAYLOAD_GEN \
     -distribution  $DISTRIBUTION \
     -payload-gen   $PAYLOAD_GEN \
     -payload_size  $PAYLOAD_SIZE \
     -msgpersec     $MSG_PER_SEC \
     -output-format $OUTPUT_FORMAT \
-    -totMessages   $TOT_MSG \
-    -file          "$OUT_FILE"
+    -totMessages   $TOT_MSG"
+if [ -n "$OUT_FILE" ] ; then
+    ARGS="$ARGS -file $OUT_FILE"
+fi
+log-stressor $ARGS


### PR DESCRIPTION
This PR fixes the run stressor script to only use outfile if it is defined as an env var


cc @eranra 